### PR TITLE
Refactor form validation and enhance CSRF protection

### DIFF
--- a/services/flask/website/forms.py
+++ b/services/flask/website/forms.py
@@ -236,9 +236,9 @@ class Server_AddOn_Form(FlaskForm):
     Used for generating QR Codes from Server_Addons table, or for storing values
     into the table itself.
     """
-    pid = StringField('PID', validators=[DataRequired()])
-    make = StringField('Make', validators=[DataRequired()])
-    model = StringField('Model', validators=[DataRequired()])
+    pid = StringField('PID')
+    make = StringField('Make')
+    model = StringField('Model')
     qty = StringField('Qty')
     submit = SubmitField('Submit')
     clear = SubmitField('Clear')

--- a/services/flask/website/static/index.js
+++ b/services/flask/website/static/index.js
@@ -1,6 +1,11 @@
 function deleteNote(noteId) {
+    let csrf_token = $('input[name="csrf_token"]').val();
+    console.log('CSRF_TOKEN:', csrf_token)
     fetch("/delete-note", {
       method: "POST",
+      headers: {
+                  'X-CSRFToken': csrf_token
+                },
       body: JSON.stringify({ noteId: noteId }),
     }).then((_res) => {
       window.location.href = "/";

--- a/services/flask/website/templates/base.html
+++ b/services/flask/website/templates/base.html
@@ -81,7 +81,8 @@
             <a class="dropdown-item" href="/test/qr-generate">QR Generation</a>
             {% endif %}
             {% if user.server_status %}
-                <a class="dropdown-item" href="/search-server-addon">Server Add-On QR Generation</a>
+                <a class="dropdown-item" href="/search-server-addon">Server Add-On QR Search</a>
+                <a class="dropdown-item" href="/new-server-addon">New Server Add-On</a>
             {% endif %}
         </div>
       </li>

--- a/services/flask/website/templates/home.html
+++ b/services/flask/website/templates/home.html
@@ -17,7 +17,8 @@
             <div class="container-fluid d-flex justify-content-center">
                 <div class="d-flex justify-content-center form-floating" style="margin-top: 20px;">
                     <form method="POST">
-                        <label for="note"></label><textarea name="note" id="note" class="note" style="justify-content; width: 300px;"></textarea>
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                        <label for="note"></label><textarea name="note" id="note" class="note" style="justify-content: center; width: 300px;"></textarea>
                         <br />
                         <button type="submit" class="login-button text-center">Add Note</button>
                     </form>

--- a/services/flask/website/views.py
+++ b/services/flask/website/views.py
@@ -559,8 +559,6 @@ def add_to_session():
     print(f'Received Data: {data}')
     quantity = data['quantity']  # Store quantity data
     pid = data['pid']  # Store PID data
-    if pid is None:
-        return jsonify({'error': 'PID is missing'}), 400
     make = data['make']  # Store Make data
     model = data['model']  # Store Model data
 


### PR DESCRIPTION
Removed field validators in form.py and added input for CSRF token in home.html to enhance application security. Instead of validating fields 'PID', 'Make', and 'Model' at the backend, these are now UI validated. CSRF token is now set in the JavaScript fetch function in the delete-note method, ensuring safer user actions. The link text in base.html file was also adjusted.