### PR TITLE
Add admin-only Reopen button for closed boxes on mobile pallet view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea/*
+__pycache__/
+*.pyc

--- a/services/flask/website/forms.py
+++ b/services/flask/website/forms.py
@@ -314,6 +314,13 @@ class MobileClosingForm(FlaskForm):
     close_pallet_button = SubmitField('Close Pallet')
 
 
+class MobileReopenBoxForm(FlaskForm):
+    """
+    Handles reopening a closed box. Admin-only action.
+    """
+    reopen_button = SubmitField('Reopen')
+
+
 class MobileNewWeightForm(FlaskForm):
     """
     Handles adding new weights to the Mobile_Weights table

--- a/services/flask/website/mobileviews.py
+++ b/services/flask/website/mobileviews.py
@@ -1,6 +1,7 @@
 from . import db, app, qrcode
 from .forms import (MobileDeviceForm, MobileClosingForm, MobileNewWeightForm, MobileBoxSearchForm,
-                    MobileBoxModificationForm, MobileWeightAdminSearchForm, ImportForm, MobileAdminAddWeightForm)
+                    MobileBoxModificationForm, MobileWeightAdminSearchForm, ImportForm, MobileAdminAddWeightForm,
+                    MobileReopenBoxForm)
 from .models import Mobile_Weights, Mobile_Pallets, Mobile_Boxes, Mobile_Box_Devices, User
 from datetime import datetime
 from decimal import Decimal
@@ -85,6 +86,8 @@ def mobile_pallet(pallet_id):
     """
     # Create an instance of the closed form.
     close_form = MobileClosingForm()
+    # Form for the admin-only "reopen box" buttons rendered under closed boxes.
+    reopen_form = MobileReopenBoxForm()
     # Query Mobile_Boxes table for all boxes associated with a given pallet id
     boxes = Mobile_Boxes.query.filter_by(palletID=pallet_id).order_by(Mobile_Boxes.box_number).all()
 
@@ -129,7 +132,29 @@ def mobile_pallet(pallet_id):
         return mobile_pallet_export(pallet_id=pallet_id)
 
     return render_template('skeleton_mobile_box_list.html', boxes=boxes, weights=weights,
-                           close_form=close_form, user=current_user)
+                           close_form=close_form, reopen_form=reopen_form, user=current_user)
+
+
+@mobileviews.route('/reopen_box/<int:box_id>', methods=['POST'])
+@login_required
+@hf.user_permissions("Mobile Admin")
+def reopen_box(box_id):
+    """
+    Reopen a closed box by setting is_active back to True. Admin-only.
+    """
+    form = MobileReopenBoxForm()
+    box = Mobile_Boxes.query.filter_by(autoID=box_id).first()
+
+    if not box:
+        flash('Box not found.', category='error')
+        return redirect(url_for('mobileviews.mobile_home'))
+
+    if form.validate_on_submit() and not box.is_active:
+        box.is_active = True
+        db.session.commit()
+        flash(f'Box {box.box_number} reopened.', category='success')
+
+    return redirect(url_for('mobileviews.mobile_pallet', pallet_id=box.palletID))
 
 
 @mobileviews.route('/box/<int:box_id>', methods=['GET', 'POST'])

--- a/services/flask/website/templates/skeleton_mobile_box_list.html
+++ b/services/flask/website/templates/skeleton_mobile_box_list.html
@@ -31,6 +31,12 @@
                         Box {{ box.box_number }} <br />
                         <span style="font-size: 12px">Weight: {{ weights[box.box_number][0] }} G: {{ weights[box.box_number][1] }} B: {{ weights[box.box_number][2] }}</span>
                     </button>
+                    {% if not box.is_active and box.autoID and (user.mobile_admin_status or user.admin_status) %}
+                        <form method="POST" action="{{ url_for('mobileviews.reopen_box', box_id=box.autoID) }}">
+                            {{ reopen_form.hidden_tag() }}
+                            {{ reopen_form.reopen_button (class="btn btn-warning btn-sm", style="width: 100%; margin-bottom: 10px") }}
+                        </form>
+                    {% endif %}
                 </div>
                 {% if loop.index % 6 == 0 and not loop.last %}
                     </div><div class="row">


### PR DESCRIPTION
Adds MobileReopenBoxForm and a POST-only /reopen_box/<id> route guarded by the Mobile Admin permission. Closed boxes in the pallet grid now show a Reopen button for mobile admins and full admins only. Also ignores __pycache__/ and *.pyc in .gitignore.